### PR TITLE
add ability to change security group rules for vpc sg's

### DIFF
--- a/dalton.py
+++ b/dalton.py
@@ -49,5 +49,5 @@ def main(config_dir, env, region, vpc_id, dry_run):
 
 
 if __name__ == '__main__':
-    options = docopt(__doc__, version='Dalton 0.1.0')
+    options = docopt(__doc__, version='Dalton 0.2.0')
     main(path(options['<config-dir>']), options['<environment>'], options['<region>'], options['--vpc'], options['--dry-run'])

--- a/dalton.py
+++ b/dalton.py
@@ -3,7 +3,7 @@
 Dalton manages your security groups.
 
 Usage:
-  dalton [-d | --dry-run] <config-dir> <environment> <region>
+  dalton [-d | --dry-run] [--vpc=<vpc_id>] <config-dir> <environment> <region>
   dalton -h | --help
   dalton --version
 
@@ -23,30 +23,31 @@ from dalton.config import YamlFileSecurityGroupsConfigLoader
 from dalton.ec2 import Ec2SecurityGroupService
 from dalton.updater import SecurityGroupUpdater
 
-
-def main(config_dir, env, region, dry_run):
+def main(config_dir, env, region, vpc_id, dry_run):
     basicConfig(
         level=INFO,
         format='%(asctime)s %(levelname)-3s %(name)s (%(funcName)s:%(lineno)d) %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
     getLogger('boto').level = CRITICAL
-
-    security_groups = YamlFileSecurityGroupsConfigLoader("%s/%s/security_groups_%s.yaml" % (config_dir, env, region)).load()
+    if vpc_id:
+      security_groups = YamlFileSecurityGroupsConfigLoader("%s/%s/security_groups_%s_%s.yaml" % (config_dir, env, region, vpc_id)).load()
+    else:
+      security_groups = YamlFileSecurityGroupsConfigLoader("%s/%s/security_groups_%s.yaml" % (config_dir, env, region)).load()
     updater = SecurityGroupUpdater(Ec2SecurityGroupService(yaml.load(open('%s/aws.yaml' % config_dir, 'r').read())[env]))
 
     for name, security_group in security_groups.iteritems():
-        created_new = updater.create_security_group_if_not_exists(name, security_group.description, region, dry_run)
+        created_new = updater.create_security_group_if_not_exists(name, security_group.description, region, vpc_id, dry_run)
         # Can't dry_run rules creation if the group doesn't actually exist yet
         if created_new and dry_run:
             continue
-        updater.update_security_group_rules(name, security_group.rules, region,
-                                            prune=security_group.prune, dry_run=dry_run)
+        updater.update_security_group_rules(name, security_group.rules, region, vpc_id, prune=security_group.prune, dry_run=dry_run)
 
     # Delete any groups that aren't listed in the ruleset config
-    updater.delete_security_group_if(lambda group: group.name not in security_groups, region, vpc=None, dry_run=dry_run)
+
+    updater.delete_security_group_if(lambda group: group.name not in security_groups, region, vpc_id, dry_run=dry_run)
 
 
 if __name__ == '__main__':
     options = docopt(__doc__, version='Dalton 0.1.0')
-    main(path(options['<config-dir>']), options['<environment>'], options['<region>'], options['--dry-run'])
+    main(path(options['<config-dir>']), options['<environment>'], options['<region>'], options['--vpc'], options['--dry-run'])

--- a/dalton/group.py
+++ b/dalton/group.py
@@ -27,7 +27,7 @@ class SecurityGroupsConfig(object):
       self.updater = SecurityGroupUpdater(self.service)
 
     def apply(self, vpc=None):
-      rack = vpc.id if vpc else None
+      rack = vpc if vpc else None
       existing_groups = {group.name: group for group in self.service.get_all(self.region, rack)}
       security_groups = self.replace_rule_security_group_names_with_ids(self.security_groups, existing_groups)
       security_groups = self.index_by_security_group_id(security_groups, existing_groups)

--- a/dalton/tests/test_updater.py
+++ b/dalton/tests/test_updater.py
@@ -2,7 +2,7 @@ import unittest
 
 from pymock import *
 
-from dalton.config import Rule, SecurityGroup
+from dalton.config import Rule
 from dalton.updater import SecurityGroupUpdater
 
 class FakeSecurityGroup(object):
@@ -10,11 +10,10 @@ class FakeSecurityGroup(object):
         self.id, self.name = id, name
 
 class SecurityGroupUpdaterTest(PyMockTestCase):
-
-    def test_update_security_group_rules_authorize_rules(self):
+    def test_update_security_group_rules_authorize_rules(self, vpc=None):
         service = self.mock()
         sg1, sg2 = FakeSecurityGroup('sg1-id', 'sg1-name'), FakeSecurityGroup('sg2-id', 'sg2-name')
-        security_group, data_center, vpc, dry_run = 'load-balancer', 'us-east-1', None, False
+        security_group, data_center, dry_run = 'load-balancer', 'us-east-1', False
         required_group_rules = frozenset([
             Rule(protocol="tcp", from_port=80,  to_port=80,  address="0.0.0.0/0"),
             Rule(protocol="tcp", from_port=443, to_port=443, address="0.0.0.0/0")
@@ -25,10 +24,13 @@ class SecurityGroupUpdaterTest(PyMockTestCase):
         self.expectAndReturn(service.get_all(data_center, vpc), [sg1, sg2])
         service.authorize_ingress_rules(security_group, required_group_rules, data_center, vpc, dry_run)
         self.replay()
-        updater.update_security_group_rules(security_group, required_group_rules, data_center)
+        updater.update_security_group_rules(security_group, required_group_rules, data_center, vpc)
         self.verify()
 
-    def test_update_security_group_rules_revoke_rules(self):
+    def test_update_security_group_rules_authorize_rules_in_vpc(self):
+        self.test_update_security_group_rules_authorize_rules(vpc="brettifer")
+
+    def test_update_security_group_rules_revoke_rules(self, vpc=None):
         service = self.mock()
         sg1, sg2 = FakeSecurityGroup('sg1-id', 'sg1-name'), FakeSecurityGroup('sg2-id', 'sg2-name')
         security_group, data_center, vpc, dry_run = 'load-balancer', 'us-east-1', None, False
@@ -45,7 +47,11 @@ class SecurityGroupUpdaterTest(PyMockTestCase):
         updater.update_security_group_rules(security_group, frozenset(), data_center, dry_run=dry_run)
         self.verify()
 
-    def test_update_security_group_rules_authorize_and_revoke_rules(self):
+    def test_update_security_group_rules_revoke_rules_in_vpc(self):
+        self.test_update_security_group_rules_revoke_rules(vpc="konkolnafulous")
+
+
+    def test_update_security_group_rules_authorize_and_revoke_rules(self, vpc=None):
         service = self.mock()
         sg1, sg2 = FakeSecurityGroup('sg1-id', 'sg1-name'), FakeSecurityGroup('sg2-id', 'sg2-name')
         security_group, data_center, vpc, dry_run = 'load-balancer', 'us-east-1', None, False
@@ -74,3 +80,6 @@ class SecurityGroupUpdaterTest(PyMockTestCase):
         self.replay()
         updater.update_security_group_rules(security_group, required_group_rules, data_center)
         self.verify()
+
+    def test_update_security_group_rules_authorize_and_revoke_rules_in_vpc(self):
+        self.test_update_security_group_rules_authorize_and_revoke_rules(vpc="jusbus")

--- a/dalton/tests/test_updater.py
+++ b/dalton/tests/test_updater.py
@@ -50,7 +50,6 @@ class SecurityGroupUpdaterTest(PyMockTestCase):
     def test_update_security_group_rules_revoke_rules_in_vpc(self):
         self.test_update_security_group_rules_revoke_rules(vpc="konkolnafulous")
 
-
     def test_update_security_group_rules_authorize_and_revoke_rules(self, vpc=None):
         service = self.mock()
         sg1, sg2 = FakeSecurityGroup('sg1-id', 'sg1-name'), FakeSecurityGroup('sg2-id', 'sg2-name')

--- a/dalton/updater.py
+++ b/dalton/updater.py
@@ -7,44 +7,44 @@ class SecurityGroupUpdater(object):
     def __init__(self, security_group_service):
         self.security_group_service = security_group_service
 
-    def update_security_group_rules(self, group_name, required_group_rules, region, vpc=None, prune=True, dry_run=False):
+    def update_security_group_rules(self, group_name, required_group_rules, region, vpc_id=None, prune=True, dry_run=False):
         # current_group_rules always have a security_group_id and only have security_group_name when in ec2 (not vpc)
         # required_group_rules could have either security_group_id or security_group_name for group rules
         # so we normalize both to have both a security_group_id and security_group_name
-        current_group_rules = self.security_group_service.get_permissions(group_name, region, vpc)
-        current_group_rules = self._normalize_security_group_rules(current_group_rules, region, vpc)
-        required_group_rules = self._normalize_security_group_rules(required_group_rules, region, vpc)
+        current_group_rules = self.security_group_service.get_permissions(group_name, region, vpc_id)
+        current_group_rules = self._normalize_security_group_rules(current_group_rules, region, vpc_id)
+        required_group_rules = self._normalize_security_group_rules(required_group_rules, region, vpc_id)
         rules_to_add = required_group_rules - current_group_rules
         rules_to_remove = current_group_rules - required_group_rules
-        location = "%s %s" % (region, vpc.id) if vpc else region
+        location = "%s %s" % (region, vpc_id) if vpc_id else region
         if rules_to_add:
             log.info('Adding rules to group %s in %s: %s', group_name, location, self._rules_str(rules_to_add))
-            self.security_group_service.authorize_ingress_rules(group_name, rules_to_add, region, vpc, dry_run)
+            self.security_group_service.authorize_ingress_rules(group_name, rules_to_add, region, vpc_id, dry_run)
         if rules_to_remove and prune:
             log.info('Removing rules from group %s in %s: %s', group_name, location, self._rules_str(rules_to_remove))
-            self.security_group_service.revoke_ingress_rules(group_name, rules_to_remove, region, vpc, dry_run)
+            self.security_group_service.revoke_ingress_rules(group_name, rules_to_remove, region, vpc_id, dry_run)
 
-    def create_security_group_if_not_exists(self, group_name, description, region, vpc=None, dry_run=False):
-        if not self.security_group_service.exists(group_name, region):
-            log.info('Creating security group %s in %s' % (group_name, region))
-            self.security_group_service.create(group_name, description, region, vpc=vpc, dry_run=dry_run)
+    def create_security_group_if_not_exists(self, group_name, description, region, vpc_id=None, dry_run=False):
+        if not self.security_group_service.exists(group_name, region, vpc_id):
+            log.info('Creating security group %s in %s %s' % (group_name, region, vpc_id if vpc_id else ""))
+            self.security_group_service.create(group_name, description, region, vpc_id=vpc_id, dry_run=dry_run)
             return True
         return False
 
-    def delete_security_group_if(self, function, region, vpc=None, dry_run=False):
-      for security_group in self.security_group_service.get_all(region, vpc=vpc):
+    def delete_security_group_if(self, function, region, vpc_id=None, dry_run=False):
+      for security_group in self.security_group_service.get_all(region, vpc_id):
         if function(security_group):
-          log.info('Deleting security group %s in %s' % (security_group.name, region))
-          self.security_group_service.delete(security_group.name, region, vpc=vpc, dry_run=dry_run)
+          log.info('Deleting security group %s in %s %s' % (security_group.name, region, vpc_id if vpc_id else ""))
+          self.security_group_service.delete(security_group.id, region, vpc_id=vpc_id, dry_run=dry_run)
 
-    def _normalize_security_group_rules(self, required_group_rules, region, vpc=None):
-        security_groups_by_id, security_groups_by_name = self._build_security_group_indices(region, vpc)
+    def _normalize_security_group_rules(self, required_group_rules, region, vpc_id=None):
+        security_groups_by_id, security_groups_by_name = self._build_security_group_indices(region, vpc_id)
         return set(rule if self._rule_has_normalized_security_groups(rule)
                    else self._normalize_security_group_source(rule, security_groups_by_id, security_groups_by_name)
                    for rule in required_group_rules)
 
-    def _build_security_group_indices(self, region, vpc=None):
-        security_groups = self.security_group_service.get_all(region, vpc)
+    def _build_security_group_indices(self, region, vpc_id=None):
+        security_groups = self.security_group_service.get_all(region, vpc_id)
         security_groups_by_id = {group.id: group for group in security_groups}
         security_groups_by_name = {group.name: group for group in security_groups}
         return security_groups_by_id, security_groups_by_name


### PR DESCRIPTION
example output:
dalton.py -d --vpc vpc-456 dalton/templates prod us-west-2
2015-12-03 17:15:02 INFO dalton.updater (update_security_group_rules:21) Adding rules to group nat_monitor_sg in us-west-2 vpc-456: ['tcp port 8008 133.17.133.37/32']
2015-12-03 17:15:03 INFO dalton.ec2 (authorize_ingress_rules:58) Request would have succeeded, but DryRun flag is set.
2015-12-03 17:15:03 INFO dalton.updater (create_security_group_if_not_exists:29) Creating security group rich in us-west-2 vpc-456
2015-12-03 17:15:04 INFO dalton.ec2 (create:27) Request would have succeeded, but DryRun flag is set.

the file for vpc will be named like this: 
dalton/templates/prod/security_groups_us-west-2_vpc-456.yaml